### PR TITLE
Importing constants with wildcards results in deprecated constant war…

### DIFF
--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -7,7 +7,7 @@ import time
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
-from homeassistant.const import *
+from homeassistant.const import CONF_TOKEN,CONF_DEVICES,STATE_ON,STATE_OFF,CONF_PASSWORD,CONF_SCAN_INTERVAL
 from homeassistant.components import persistent_notification
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.storage import Store


### PR DESCRIPTION
…nings

The warning itself seems to be safe to leave alone, but not so many constants seem to be used. Changed to import constants that are clearly used.