### PR TITLE
Fix Got devices failed

### DIFF
--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -239,6 +239,9 @@ class Account:
         return old
 
     async def get_devices(self):
+        if not self._config.token:
+            if not await self.async_login():
+                return []
         api = 'token/device/union/list/sorted'
         rsp = await self.request(api, {'type': 'NONE'})
         eno = rsp.get('returnCode', 0)

--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -244,7 +244,7 @@ class Account:
         eno = rsp.get('returnCode', 0)
         if eno == 1002:  # Illegal token
             if await self.async_login():
-                rsp = await self.request(api)
+                rsp = await self.request(api, {'type': 'NONE'})
         dls = rsp.get('data', {}).get(CONF_DEVICES) or []
         if not dls:
             _LOGGER.warning('Got devices for %s failed: %s', self.phone, rsp)

--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -239,7 +239,7 @@ class Account:
         return old
 
     async def get_devices(self):
-        if not self._config.token:
+        if not self.token:
             if not await self.async_login():
                 return []
         api = 'token/device/union/list/sorted'


### PR DESCRIPTION
issue #1 

Possibly due to a problem with the catlink server, the following error may occur when logging in.

```
Login 000000000 failed: [{'returnCode': 2001, 'toast': False, 'msg': '用户不存在，请先注册', 'data': {}, 'timestamp': '1716092971910', 'success': False}, {'platform': 'ANDROID', 'internationalCode': '00', 'mobile': '000000000', 'password': 'password', 'noncestr': 1716092971792, 'sign': 'sign'}]
```

When the login fails, `Account.token` will be set to an empty string. Due to the lack of `Account.token`, the response from the device is `{'msg': 'Device offline or other faults','returnCode': 1000'}`. However, the system Will not Login again because `returnCode` != 1002. This resulted in ongoing issues getting the devices.