### PR TITLE
Deprecate hass.helpers usage (stop working in Home Assistant 2024.11)

### DIFF
--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
 
 from asyncio import TimeoutError
 from aiohttp import ClientConnectorError
@@ -113,7 +114,7 @@ async def async_setup(hass: HomeAssistant, hass_config: dict):
 
     for platform in SUPPORTED_DOMAINS:
         hass.async_create_task(
-            hass.helpers.discovery.async_load_platform(platform, DOMAIN, {}, config)
+            async_load_platform(hass, platform, DOMAIN, {}, config)
         )
 
     return True


### PR DESCRIPTION
Recently, the following warning was output to the log.

```
2024-08-17 13:51:00.457 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'catlink' accesses hass.helpers.discovery. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from discovery directly at custom_components/catlink/__init__.py, line 116: hass.helpers.discovery.async_load_platform(platform, DOMAIN, {}, config), please create a bug report at https://github.com/hasscc/catlink/issues
```

After checking, I found that the way to access helpers has changed.
[Source 1](https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/ "Deprecate hass.helpers usage")
[Source 2](https://github.com/mampfes/hacs_waste_collection_schedule/pull/2028/files "remove deprecated function call 'async_load_platform' #2028")

This change is in response to this.