### PR TITLE
[SCOOPER C1] Added new states, attributes, usage tracking, etc.

### DIFF
--- a/custom_components/catlink/__init__.py
+++ b/custom_components/catlink/__init__.py
@@ -745,8 +745,8 @@ class LitterBox(Device):
     def knob_status(self) -> bool:
         knob_flab = any(
             "left_knob_abnormal" in e.get("errkey")
-            for e in self.detail.get("deviceErrorList")
-        )
+            for e in self.detail.get("deviceErrorList", [])
+        ) if self.detail else False
         return "Empty Mode" if knob_flab else "Cleaning Mode"
 
     @property
@@ -777,8 +777,8 @@ class LitterBox(Device):
     def garbage_tobe_status(self) -> str:
         full_flag = any(
             "garbage_tobe_full_abnormal" in e.get("errkey")
-            for e in self.detail.get("deviceErrorList")
-        )
+            for e in self.detail.get("deviceErrorList", [])
+        ) if self.detail else False
         return "Full" if full_flag else "Normal"
 
     @property


### PR DESCRIPTION
Hi there 👋,

Another PR for the SCOOPER C1 (SE).

According to the discussion on the issue [Issue!11](https://github.com/hasscc/catlink/issues/11#issuecomment-2306971204)  user @GOUKI9999 reported that `error entity` doesn't work, that's because it is stored in the `deviceErrorList` attribute. Well, that was an easy fix. 

I've also utilized errors that are persistent in that attribute to create `garbage_tobe_status` and `knob_status` entities, basically by checking whether a certain `errkey` is presented in the error list. 

Added support for cat presence, by checking sampling litter_weight during the day, and then if changes, most cats are in the litterbox. This device doesn't have any PIR or proximity sensors to determine whether the cat is in the litterbox, and CATLINK does the same logic to calculate the cat's presence in the litterbox.

Among other fixes, this is what entities look like for the SCOOPER C1 (LitterBox Class):

![image](https://github.com/user-attachments/assets/d6b655fb-8ac6-45c4-a5c0-302e119a157d)

My next steps would be to utilize `/cats/health` API to fetch available cats, and their health status, and to add multi-cat support for those who don't have that activated (like me, lol).

Have a good one community <3