### PR TITLE
Added additional configuration per device

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ catlink:
   scan_interval: # Optional, default is 00:01:00
   language: "en_GB"
 
+  devices: # Optional
+    - name: "Scooper C1" # Optional 
+      mac: "AABBCCDDEE" # Optional
+      empty_weight: 3.0 # (Optional) Empty litterbox weight defaults to 0.0
+      max_samples_litter: 24 # (Optional) Number of samples to determinate whether cat is inside
+
+
   # Multiple accounts
   accounts:
     - username: 18866660001

--- a/custom_components/catlink/models/additional_cfg.py
+++ b/custom_components/catlink/models/additional_cfg.py
@@ -1,0 +1,12 @@
+"""Models for additional device configuration."""
+
+from pydantic import BaseModel
+
+
+class AdditionalDeviceConfig(BaseModel):
+    """Additional device configuration."""
+
+    name: str = ""
+    mac: str = ""
+    empty_weight: float = 0.0
+    max_samples_litter: int = 24


### PR DESCRIPTION
Hello @al-one, 🐱 

After replacing the pad, I found it almost impossible to re-calibrate the device to present proper litter weight, 
So I added additional options for users who face issues like me. 

Now we have the option to add empty_weight as a configuration parameter for each device, 
so the module can properly represent litter weight, so users can use that to push notifications when it is low.


Regards