### PR TITLE
fix: handle timedelta type in calculate_update_interval

### DIFF
--- a/custom_components/catlink/helpers.py
+++ b/custom_components/catlink/helpers.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from homeassistant.core import HomeAssistant
 
@@ -16,25 +16,31 @@ class Helper:
     """Helper class for the CatLink integration."""
 
     @classmethod
-    def calculate_update_interval(cls, update_interval_str: str) -> timedelta:
-        """Calculate the update interval as a timedelta object based on the given update_interval_str.
+    def calculate_update_interval(cls, update_interval: Union[str, timedelta]) -> timedelta:
+        """Calculate the update interval as a timedelta object.
 
         Args:
-            update_interval_str (str): The update interval string in the format "HH:MM:SS".
+            update_interval: The update interval as a string ("HH:MM:SS") or timedelta.
+                When configured via YAML, Home Assistant's cv.time_period validator
+                converts the string to a timedelta object.
 
         Returns:
             timedelta: The update interval as a timedelta object.
 
         """
+        # If already a timedelta (from cv.time_period validation), return directly
+        if isinstance(update_interval, timedelta):
+            return update_interval
 
+        # Handle string format "HH:MM:SS"
         return (
             timedelta(minutes=10)
-            if not update_interval_str
-            or not re.match(r"^\d{2}:\d{2}:\d{2}$", update_interval_str)
+            if not update_interval
+            or not re.match(r"^\d{2}:\d{2}:\d{2}$", update_interval)
             else timedelta(
-                hours=int(update_interval_str[:2]),
-                minutes=int(update_interval_str[3:5]),
-                seconds=int(update_interval_str[6:8]),
+                hours=int(update_interval[:2]),
+                minutes=int(update_interval[3:5]),
+                seconds=int(update_interval[6:8]),
             )
         )
 


### PR DESCRIPTION
## Summary
- Fix TypeError when `CONF_SCAN_INTERVAL` is validated by Home Assistant's `cv.time_period`
- The validator converts the config string to a `timedelta` object, but `calculate_update_interval` only expected a string
- Now supports both string ("HH:MM:SS") and `timedelta` inputs

## Problem
When using YAML configuration, Home Assistant throws:
```
Error during setup of component catlink: expected string or bytes-like object, got 'datetime.timedelta'
```

This happens because `const.py` defines:
```python
vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
```

The `cv.time_period` validator converts the string to a `timedelta` object before it reaches `calculate_update_interval`.

## Test plan
- [x] Tested with YAML configuration on Home Assistant 2024.12+
- [x] Verified catlink integration loads successfully after fix

🤖 Generated with [Claude Code](https://claude.ai/code)