### PR TITLE
Fix HA 2026.2.0 compatibility

### DIFF
--- a/custom_components/catlink/entitites/catlink.py
+++ b/custom_components/catlink/entitites/catlink.py
@@ -3,6 +3,7 @@
 from homeassistant.components import persistent_notification
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from ..const import _LOGGER, DOMAIN
 from ..modules.device import Device
@@ -23,11 +24,12 @@ class CatlinkEntity(CoordinatorEntity):
         self._attr_device_id = f"{device.type}_{device.mac}"
         self._attr_unique_id = f"{self._attr_device_id}-{name}"
         mac = device.mac[-4:] if device.mac else device.id
-        self.entity_id = f"{DOMAIN}.{device.type.lower()}_{mac}_{name}"
+        object_id = f"{device.type}_{mac}_{name}"
+        self.entity_id = f"{DOMAIN}.{slugify(object_id)}"
         self._attr_icon = self._option.get("icon")
         self._attr_device_class = self._option.get("class")
-        self._attr_unit_of_measurement = self._option.get("unit")
-        self._attr_state_class = option.get("state_class")
+        self._attr_native_unit_of_measurement = self._option.get("unit")
+        self._attr_state_class = self._option.get("state_class")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_device_id)},
             name=device.name,
@@ -68,7 +70,7 @@ class CatlinkEntity(CoordinatorEntity):
         throw = kwargs.pop("throw", None)
         rdt = await self.account.request(api, params, method, **kwargs)
         if throw:
-            persistent_notification.create(
+            persistent_notification.async_create(
                 self.hass,
                 f"{rdt}",
                 f"Request: {api}",

--- a/custom_components/catlink/modules/account.py
+++ b/custom_components/catlink/modules/account.py
@@ -109,7 +109,9 @@ class Account:
             kws["data"] = pms
         try:
             req = await self.http.request(method, url, **kws)
-            return await req.json() or {}
+            result = await req.json() or {}
+            _LOGGER.debug("API response %s %s: %s", method, api, result)
+            return result
         except (ClientConnectorError, TimeoutError) as exc:  # noqa: UP041
             _LOGGER.error("Request api failed: %s", [method, url, pms, exc])
         return {}

--- a/custom_components/catlink/modules/devices_coordinator.py
+++ b/custom_components/catlink/modules/devices_coordinator.py
@@ -73,6 +73,7 @@ class DevicesCoordinator(DataUpdateCoordinator):
         add = self.hass.data[DOMAIN]["add_entities"].get(domain)
         if not add or not hasattr(dvc, hdk):
             return
+        added_entity_ids: list[str] = []
         for k, cfg in getattr(dvc, hdk).items():
             key = f"{domain}.{k}.{dvc.id}"
             new = None
@@ -91,3 +92,10 @@ class DevicesCoordinator(DataUpdateCoordinator):
             if new:
                 self._subs[key] = new
                 add([new])
+                added_entity_ids.append(new.entity_id)
+        if added_entity_ids:
+            _LOGGER.info(
+                "Device %s entities: %s",
+                dvc.name,
+                added_entity_ids,
+            )


### PR DESCRIPTION
- Use slugify() for entity IDs to fix invalid entity ID errors (uppercase in MAC)
- Replace unit_of_measurement with native_unit_of_measurement for sensors
- Use persistent_notification.async_create instead of create in async context
- Fix option.get to self._option.get for state_class to handle None option
- Add API response debug logging in account request method
- Add device entity list info logging when entities are added