### PR TITLE
fix: Add 'number' to component types list

### DIFF
--- a/custom_components/catlink/const.py
+++ b/custom_components/catlink/const.py
@@ -66,6 +66,7 @@ SUPPORTED_DOMAINS = [
     "switch",
     "select",
     "button",
+    "number",
 ]
 
 ACCOUNT_SCHEMA = vol.Schema(


### PR DESCRIPTION
missing supported domain